### PR TITLE
compatibility upgrade to Qt5/Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 Pedro López-Cabanillas <plcl@users.sf.net>
+# SPDX-License-Identifier: Apache-2.0
+# ~~~
+cmake_minimum_required(VERSION 3.16)
+
+project(rifftree
+    LANGUAGES CXX
+    VERSION 1.0
+)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+    riff.h
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
+)
+
+target_compile_definitions( ${PROJECT_NAME} PRIVATE
+    VERSION=${PROJECT_VERSION}
+    PROGRAM=${PROJECT_NAME}
+)
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# A console application to show the tree structure of a RIFF file.
+
+This is a Qt5/Qt6 console application showing the structure of a [RIFF file](https://en.wikipedia.org/wiki/Resource_Interchange_File_Format).
+Instead of reading and parsing the file (which may be quite large), it is [memory mapped](https://en.wikipedia.org/wiki/Memory-mapped_file) and should be very efficient.
+
+## Usage
+
+```
+    $ ./rifftree -h
+    Usage: ./rifftree [options] file
+    
+    Options:
+      -h, --help     Displays help on commandline options.
+      --help-all     Displays help including Qt specific options.
+      -v, --version  Displays version information.
+    
+    Arguments:
+      file           RIFF file
+```
+
+## Sample Output
+
+```
+    $ ./rifftree WIND2.wav
+                  0 RIFF(WAVE) -> size=156582
+                 12    fmt  size=16
+                 36    data size=156546
+```
+
+## License
+
+Copyright (C) 2013 Jesús Torres <jmtorres@ull.es>  
+Copyright (C) 2025 Pedro López-Cabanillas <plcl@users.sf.net>  
+SPDX-License-Identifier: Apache-2.0

--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ void traverseRiff(const riff::RiffList<>::Chunk* listChunk, int indentWidth)
     const riff::RiffChunk<>* child = listChunk->data->chunks;
     const void* end = listChunk->dataEnd();
     while (child < end) {
-        if (child->hasTypeList()) {
+        if (child->hasTypeList() || child->hasTypeRiff()) {
             traverseRiff(child->castTo<riff::RiffList<> >(), childIndent);
         } else {
             cout.setFieldWidth(15);

--- a/main.cpp
+++ b/main.cpp
@@ -129,4 +129,8 @@ int main(int argc, char *argv[])
 
     // Traverse the RIFF file and print its structure
     traverseRiff(chunk->castTo<riff::RiffList<> >(), 0);
+
+    // Cleanup
+    rifffile.unmap(g_buffer);
+    rifffile.close();
 }

--- a/riff.h
+++ b/riff.h
@@ -57,7 +57,7 @@ struct RiffChunk
 
     uint32_t type;
     uint32_t size;
-    D data[];
+    D data[1];
 
     //
     // Known types of chunks
@@ -165,7 +165,7 @@ struct RiffList
     typedef RiffChunk<RiffList<D> > Chunk;
 
     uint32_t listType;
-    RiffChunk<D> chunks[];
+    RiffChunk<D> chunks[1];
 
     std::string listTypeToStdString() const
     {

--- a/riff.h
+++ b/riff.h
@@ -1,3 +1,7 @@
+// Copyright (C) 2013 Jesús Torres <jmtorres@ull.es>
+// Copyright (C) 2025 Pedro López-Cabanillas <plcl@users.sf.net>
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * riff.h - RIFF file format data types
  *
@@ -19,11 +23,11 @@
 #ifndef RIFF_H
 #define RIFF_H
 
-#if defined QT_VERSION
+#if defined(QT_CORE_LIB)
 #include <QString>
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 namespace riff
@@ -39,8 +43,10 @@ struct RiffList;
 // to the type of data stored.
 //
 
-#pragma pack(4)
-template <typename D = uint8_t>
+constexpr int alignsize{sizeof(uint32_t)};
+
+#pragma pack(push, alignsize)
+template<typename D = uint8_t>
 struct RiffChunk
 {
     typedef RiffChunk<D> Type;
@@ -57,9 +63,9 @@ struct RiffChunk
     // Known types of chunks
     //
 
-    static const uint32_t TYPE_RIFF = 0x46464952;
-    static const uint32_t TYPE_LIST = 0x5453494C;
-    static const uint32_t TYPE_INFO = 0x4F464E49;
+    static constexpr uint32_t TYPE_RIFF = 0x46464952;
+    static constexpr uint32_t TYPE_LIST = 0x5453494C;
+    static constexpr uint32_t TYPE_INFO = 0x4F464E49;
 
     bool hasTypeRiff() const
     {
@@ -77,27 +83,30 @@ struct RiffChunk
                     reinterpret_cast<const char*>(&type), sizeof(type));
     }
 
-#if defined QT_VERSION
+#if defined(QT_CORE_LIB)
     QString typeToQString() const
     {
         return QString::fromLatin1(
                     reinterpret_cast<const char*>(&type), sizeof(type));
     }
-#endif /* QT_VERSION */
+#endif
 
     //
     // Get a pointer to the end of data section
     //
 
-    void* dataEnd()
+    void *dataEnd() { return reinterpret_cast<uint8_t *>(data) + size; }
+
+    //
+    // Get the offset to the beginning of the structure
+    //
+
+    const uintptr_t offset(uint8_t *baseptr) const
     {
-        return reinterpret_cast<const uint8_t*>(data) + size;
+        return reinterpret_cast<const uint8_t *>(&type) - baseptr;
     }
 
-    const void* dataEnd() const
-    {
-        return reinterpret_cast<const uint8_t*>(data) + size;
-    }
+    const void *dataEnd() const { return reinterpret_cast<const uint8_t *>(data) + size; }
 
     //
     // Get a pointer to the next chunk (16-bit aligned)
@@ -106,13 +115,13 @@ struct RiffChunk
     template <typename C = uint8_t>
     RiffChunk<C>* nextChunk()
     {
-        return reinterpret_cast<RiffChunk<C>*>(alignPointer(dataEnd(), 2));
+        return reinterpret_cast<RiffChunk<C> *>(alignPointer(dataEnd(), sizeof(int16_t)));
     }
 
     template <typename C = uint8_t>
     const RiffChunk<C>* nextChunk() const
     {
-        return reinterpret_cast<const RiffChunk<C>*>(alignPointer(dataEnd(), 2));
+        return reinterpret_cast<const RiffChunk<C> *>(alignPointer(dataEnd(), sizeof(int16_t)));
     }
 
     //
@@ -149,8 +158,7 @@ private:
 // Data type of data section in chunks of type RIFF list
 //
 
-#pragma pack(4)
-template <typename D = uint8_t>
+template<typename D = uint8_t>
 struct RiffList
 {
     typedef RiffList<D> Type;
@@ -165,19 +173,19 @@ struct RiffList
                            sizeof(listType));
     }
 
-#if defined QT_VERSION
+#if defined(QT_CORE_LIB)
     QString listTypeToQString() const
     {
-        return QString::fromLatin1(reinterpret_cast<const char*>(&listType),
-                                   sizeof(&listType));
+        return QString::fromLatin1(reinterpret_cast<const char *>(&listType), sizeof(listType));
     }
-#endif /* QT_VERSION */
+#endif
 
 private:
     RiffList()
         : RiffList<D>()
     {}
 };
+#pragma pack(pop)
 
 } // namespace riff
 


### PR DESCRIPTION
This is a compatibility upgrade to Qt5/Qt6

Changes:
    * add a CMake build system
    * add README.md
    * add SPDX license identifiers
    * riff.h: new RiffChunk::offset() function and other minor changes
    * main.cpp: replace getopt by QCommandLineParser
    * main.cpp: add offset and size output
    * main.cpp cleanup
    * main.cpp: fix for RMI files may contain an embedded RIFF(DLS) chunk inside. 
       Examples: https://archive.org/details/RIFF-MIDI-DLS

This updated riff.h is used in this project: https://github.com/pedrolcl/RiffTreeGUI
